### PR TITLE
Add Content-Type JSON to make the list of files available via storage

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -448,6 +448,7 @@ func (f *file) List(queryPath string, options FileSearchOptions) []FileObject {
 
 	reqURL := fmt.Sprintf("%s/%s/object/list/%s", f.storage.client.BaseURL, StorageEndpoint, f.BucketId)
 	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewBuffer(_json))
+	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
I noticed that the list of files method was not usable due to the missing Content-Type JSON. This is an easy fix for this issue.